### PR TITLE
feat: modify workflow to use hybrid workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,11 +13,9 @@ permissions:
   id-token: write
 
 jobs:
-  deploy:
-    name: Deploy to GitHub Pages
+  build:
+    name: Build to GitHub Pages
     runs-on: ubuntu-latest
-    environment:
-      name: github-pages
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -35,5 +33,15 @@ jobs:
         with:
           name: github-pages
           path: ./build
-      
+
+  deploy:
+    name: Deploy to GitHub Pages
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: github-pages
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: site-build
       - uses: actions/deploy-pages@v4


### PR DESCRIPTION
Changing workflow to use both GitHub-hosted and self-hosted runners because GitHub Pages can't be deployed from self-hosted runners.